### PR TITLE
fix for https://github.com/shogo4405/HaishinKit.dart/issues/27 taking…

### DIFF
--- a/haishinkit/src/main/java/com/haishinkit/rtmp/RtmpAuthenticator.kt
+++ b/haishinkit/src/main/java/com/haishinkit/rtmp/RtmpAuthenticator.kt
@@ -73,7 +73,17 @@ internal class RtmpAuthenticator(val connection: RtmpConnection) : IEventListene
     private fun createAuthCommand(uri: URI, description: String): String {
         if (!description.contains("?")) return uri.toString()
         if (uri.rawUserInfo == null) return uri.toString()
-        val command = createAuthQuery(uri)
+        var command = ""
+        if (uri.path.endsWith('/')) {
+            // remove last trailing slash and everything after
+            // so that createAuthQuery won't duplicate authmod=adobe&user=$user
+            // see https://github.com/shogo4405/HaishinKit.dart/issues/27
+            val uriString = uri.toString();
+            val uriTemp = URI(uriString.substring(0, uriString.lastIndexOf('/')))
+            command = createAuthQuery(uriTemp)
+        } else {
+            command = createAuthQuery(uri)
+        }
         val query = description.split("?")[1]
         val descriptionUri = Uri.parse("https://localhost?$query")
         val info = Info(


### PR DESCRIPTION
Fix for https://github.com/shogo4405/HaishinKit.dart/issues/27

Added additional URI checks in the createAuthCommand command for [RtmpAuthentificator.kt](https://github.com/shogo4405/HaishinKit.kt/blob/2ce69965eba61677e0e205c302e951a39cdcf465/haishinkit/src/main/java/com/haishinkit/rtmp/RtmpAuthenticator.kt#L73)
Includes [Wowza tests](https://github.com/shogo4405/HaishinKit.kt/pull/154#issuecomment-1575172708) and removed the original `+ "?"` that added breaking changes for RTMP mount validation.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

