### PR TITLE
fixed blue and red were swapped on Pixel 5a.

### DIFF
--- a/haishinkit/src/main/java/com/haishinkit/media/Camera2Source.kt
+++ b/haishinkit/src/main/java/com/haishinkit/media/Camera2Source.kt
@@ -263,8 +263,7 @@ class Camera2Source(
     }
 
     companion object {
-        private const val IMAGE_FORMAT = ImageFormat.YUV_420_888
-
+        private const val IMAGE_FORMAT = 0x00000022 // AIMAGE_FORMAT_PRIVATE
         private const val DEFAULT_CAMERA_ID = "0"
         private val TAG = Camera2Source::class.java.simpleName
     }

--- a/vulkan/src/main/cpp/Graphics/ImageReader.cpp
+++ b/vulkan/src/main/cpp/Graphics/ImageReader.cpp
@@ -13,16 +13,19 @@ void ImageReader::SetUp(int32_t width, int32_t height, int32_t format) {
     buffers.resize(maxImages);
     images.resize(maxImages);
 
-    AImageReader_newWithUsage(
+    auto result = AImageReader_newWithUsage(
             width,
             height,
             format,
-            AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
-            AHARDWAREBUFFER_USAGE_CPU_READ_RARELY,
+            AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE,
             maxImages + 2,
             &reader);
 
-    AImageReader_getWindow(reader, &window);
+    if (result == AMEDIA_OK) {
+        AImageReader_getWindow(reader, &window);
+    } else {
+        LOGE("Failed to AImageReader_newWithUsage error: %d", result);
+    }
 }
 
 void ImageReader::TearDown() {
@@ -38,6 +41,9 @@ ANativeWindow *ImageReader::GetWindow() {
 }
 
 AHardwareBuffer *ImageReader::GetLatestBuffer() {
+    if (reader == nullptr) {
+        return nullptr;
+    }
     if (cursor == buffers.size()) {
         cursor = 0;
     }

--- a/vulkan/src/main/java/com/haishinkit/vulkan/VkPixelTransform.kt
+++ b/vulkan/src/main/java/com/haishinkit/vulkan/VkPixelTransform.kt
@@ -148,7 +148,7 @@ class VkPixelTransform : PixelTransform {
         format: Int,
         lambda: (surface: Surface) -> Unit
     ) {
-        lambda(nativeCreateInputSurface(width, height, format))
+        nativeCreateInputSurface(width, height, format)?.let { lambda(it) }
     }
 
     override fun dispose() {
@@ -163,7 +163,7 @@ class VkPixelTransform : PixelTransform {
     private external fun nativeSetVideoGravity(videoGravity: Int)
     private external fun nativeSetImageExtent(width: Int, height: Int)
     private external fun nativeSetAssetManager(assetManager: AssetManager?)
-    private external fun nativeCreateInputSurface(width: Int, height: Int, format: Int): Surface
+    private external fun nativeCreateInputSurface(width: Int, height: Int, format: Int): Surface?
     private external fun nativeSetRotatesWithContent(expectedOrientationSynchronize: Boolean)
     private external fun nativeSetFrameRate(frameRate: Int)
     private external fun nativeSetVideoEffect(videoEffect: VideoEffect)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- fixed blue and red were swapped on Pixel 5a.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:
|BEFORE|AFTER|
|:-:|:-:|
|![screencap-2024-01-03T093652 307Z](https://github.com/shogo4405/HaishinKit.kt/assets/810189/2cc92f98-0ad1-461e-8274-4a2e6fc3479e)|![screencap-2024-01-04T112245 446Z](https://github.com/shogo4405/HaishinKit.kt/assets/810189/671c6986-7908-48b6-b155-6ac0560a788e)|


